### PR TITLE
Correct tests so that expected branches are covered.

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -356,7 +356,7 @@ class TestLoader(unittest.TestCase):
     def testInvalidBooleanLiteral(self, m):
         '''
         CREATE TABLE X (B BOOLEAN);
-        INSERT INTO X ('test');
+        INSERT INTO X VALUES ('test');
         '''
 
     @expect_exception(xtuml.ParsingException)
@@ -364,7 +364,7 @@ class TestLoader(unittest.TestCase):
     def testInvalidType(self, m):
         '''
         CREATE TABLE X (VAR SOME_TYPE);
-        INSERT INTO X ('test');
+        INSERT INTO X VALUES ('test');
         '''
 
     @load

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -550,6 +550,28 @@ class TestQuerySet(unittest.TestCase):
         q1.pop(last=False)
         self.assertEqual(q1, q2)
 
+class TestIdGenerator(unittest.TestCase):
+    '''
+    Test suite for the IdGenerator classes
+    '''
+
+    def testIntegerGeneratorBasic(self):
+        i = xtuml.IntegerGenerator()
+        self.assertEqual(i.peek(), 1)
+        self.assertEqual(i.next(), 1)
+        self.assertEqual(i.next(), 2)
+        self.assertEqual(i.peek(), 3)
+        self.assertEqual(i.peek(), 3)
+
+    def testIntegerGeneratorIterator(self):
+        i = xtuml.IntegerGenerator()
+        count = 1
+        for v in i:
+            self.assertEqual(v, count)
+            count += 1
+            if count == 10:
+                break;
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The tests did not cover all branches it should, due to syntax errors in test scripts.
